### PR TITLE
Track Ray IDs and Client IPs

### DIFF
--- a/html/cloudflare-1000-error.htm
+++ b/html/cloudflare-1000-error.htm
@@ -203,6 +203,8 @@
       </ul>
     </footer>
 
+    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::" />
+
     <script>
       document.getElementById(
         "copyright-date"

--- a/html/cloudflare-1000-error.htm
+++ b/html/cloudflare-1000-error.htm
@@ -203,7 +203,7 @@
       </ul>
     </footer>
 
-    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::" />
+    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::&client-ip=::CLIENT_IP::" />
 
     <script>
       document.getElementById(

--- a/html/cloudflare-1000-error.htm
+++ b/html/cloudflare-1000-error.htm
@@ -203,7 +203,7 @@
       </ul>
     </footer>
 
-    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::&client-ip=::CLIENT_IP::" />
+    <img src="https://volley.artsy.net/cloudflareError.png?cloudflareErrorType=1000&rayID=::RAY_ID::&clientIP=::CLIENT_IP::" />
 
     <script>
       document.getElementById(

--- a/html/cloudflare-500-error.htm
+++ b/html/cloudflare-500-error.htm
@@ -203,6 +203,8 @@
       </ul>
     </footer>
 
+    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::" />
+
     <script>
       document.getElementById(
         "copyright-date"

--- a/html/cloudflare-500-error.htm
+++ b/html/cloudflare-500-error.htm
@@ -203,7 +203,7 @@
       </ul>
     </footer>
 
-    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::" />
+    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::&client-ip=::CLIENT_IP::" />
 
     <script>
       document.getElementById(

--- a/html/cloudflare-500-error.htm
+++ b/html/cloudflare-500-error.htm
@@ -203,7 +203,7 @@
       </ul>
     </footer>
 
-    <img src="https://hokusai-sandbox.artsy.net/pixel.png?ray-id=::RAY_ID::&client-ip=::CLIENT_IP::" />
+    <img src="https://volley.artsy.net/cloudflareError.png?cloudflareErrorType=500&rayID=::RAY_ID::&clientIP=::CLIENT_IP::" />
 
     <script>
       document.getElementById(


### PR DESCRIPTION
Loads a png from `https://volley.artsy.net/cloudflareError.png` - this logs the `RAY_ID` and `CLIENT_IP` and emits a counter metric so we can track Cloudflare origin errors