### PR TITLE
fix template rendering for error reporting image

### DIFF
--- a/html/cloudflare-1000-error.htm
+++ b/html/cloudflare-1000-error.htm
@@ -198,7 +198,18 @@
       </ul>
     </footer>
 
-    <img src="https://volley.artsy.net/cloudflareError.png?cloudflareErrorType=1000&rayID=::RAY_ID::&clientIP=::CLIENT_IP::" />
+    <div id="error">
+      <div id="rayID">::RAY_ID::</div>
+      <div id="clientIP">::CLIENT_IP::</div>
+    </div>
+
+    <script>
+      var rayID = document.getElementById("rayID").innerHTML;
+      var clientIP = document.getElementById("clientIP").innerHTML;
+      var errorReport = document.createElement("IMG");
+      errorReport.src = 'https://volley.artsy.net/cloudflareError.png?cloudflareErrorType=1000&rayID=' + rayID + '&clientIP=' + clientIP;
+      document.getElementById("error").appendChild(errorReport);
+    </script>
 
     <script>
       document.getElementById(

--- a/html/cloudflare-1000-error.htm
+++ b/html/cloudflare-1000-error.htm
@@ -145,6 +145,10 @@
     .contact-support {
       margin-bottom: 32px;
     }
+
+    .hidden {
+      visibility: hidden;
+    }
   </style>
 
   <body>
@@ -198,7 +202,7 @@
       </ul>
     </footer>
 
-    <div id="error">
+    <div id="error" class="hidden">
       <div id="rayID">::RAY_ID::</div>
       <div id="clientIP">::CLIENT_IP::</div>
     </div>

--- a/html/cloudflare-500-error.htm
+++ b/html/cloudflare-500-error.htm
@@ -145,6 +145,10 @@
     .contact-support {
       margin-bottom: 32px;
     }
+
+    .hidden {
+      visibility: hidden;
+    }
   </style>
 
   <body>
@@ -198,7 +202,7 @@
       </ul>
     </footer>
 
-    <div id="error">
+    <div id="error" class="hidden">
       <div id="rayID">::RAY_ID::</div>
       <div id="clientIP">::CLIENT_IP::</div>
     </div>

--- a/html/cloudflare-500-error.htm
+++ b/html/cloudflare-500-error.htm
@@ -198,12 +198,24 @@
       </ul>
     </footer>
 
-    <img src="https://volley.artsy.net/cloudflareError.png?cloudflareErrorType=500&rayID=::RAY_ID::&clientIP=::CLIENT_IP::" />
+    <div id="error">
+      <div id="rayID">::RAY_ID::</div>
+      <div id="clientIP">::CLIENT_IP::</div>
+    </div>
+
+    <script>
+      var rayID = document.getElementById("rayID").innerHTML;
+      var clientIP = document.getElementById("clientIP").innerHTML;
+      var errorReport = document.createElement("IMG");
+      errorReport.src = 'https://volley.artsy.net/cloudflareError.png?cloudflareErrorType=500&rayID=' + rayID + '&clientIP=' + clientIP;
+      document.getElementById("error").appendChild(errorReport);
+    </script>
 
     <script>
       document.getElementById(
         "copyright-date"
       ).innerHTML = new Date().getFullYear();
     </script>
+
   </body>
 </html>


### PR DESCRIPTION
So Cloudflare couldn't render a template with `::RAY_ID::` or `::CLIENT_IP::` interpolated into a string like that.  It works when these template vars are innerHTML of an element, so template them out to divs then grab the values and load the error reporting image via Javascript

cc @joeyAghion 
